### PR TITLE
Assign OpenScale icon to Lose It

### DIFF
--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1685,6 +1685,9 @@
     <!-- Loop Habit Tracker -->
     <item component="ComponentInfo{org.isoron.uhabits/org.isoron.uhabits.MainActivity}" drawable="loop" />
 
+    <!-- Lose It! -->
+    <item component="ComponentInfo{com.fitnow.loseit/com.fitnow.loseit.MainActivity}" drawable="openscale"/>
+
     <!-- Loyalty Card Keychain -->
     <item component="ComponentInfo{protect.card_locker/protect.card_locker.MainActivity}" drawable="loyaltycardkeychain" />
 


### PR DESCRIPTION
Nobody will be using both, and the icons are close enough. Is it perfect? No, but not every launcher supports arbitrary icons.