### PR TITLE
Add RetroArch Plus

### DIFF
--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -2970,6 +2970,7 @@
 
     <!-- RetroArch -->
     <item component="ComponentInfo{com.retroarch/com.retroarch.browser.mainmenu.MainMenuActivity}" drawable="retroarch" />
+    <item component="ComponentInfo{com.retroarch.aarch64/com.retroarch.browser.mainmenu.MainMenuActivity}" drawable="retroarch"/>
 
     <!-- Revolution -->
     <item component="ComponentInfo{io.mrarm.irc/io.mrarm.irc.MainActivity}" drawable="revolution" />


### PR DESCRIPTION
[RetroArch](https://play.google.com/store/apps/details?id=com.retroarch) on Google Play Store is now replaced by [RetroArch Plus](https://play.google.com/store/apps/details?id=com.retroarch.aarch64), hence the small update.