### PR TITLE
Added new RiseUp VPN activity name

### DIFF
--- a/app/src/main/assets/appfilter.xml
+++ b/app/src/main/assets/appfilter.xml
@@ -4579,6 +4579,7 @@
 
     <!-- Riseup VPN -->
     <item component="ComponentInfo{se.leap.riseupvpn/se.leap.bitmaskclient.StartActivity}" drawable="riseupvpn" />
+    <item component="ComponentInfo{se.leap.riseupvpn/se.leap.bitmaskclient.base.StartActivity}" drawable="riseupvpn"/>
 
     <!-- RoadEagle -->
     <item component="ComponentInfo{org.traffxml.roadeagle/org.traffxml.roadeagle.android.ui.MainActivity}" drawable="roadeagle"/>


### PR DESCRIPTION
Just updated the RiseUP VPN app' and it reverted back to the old icon.
I checked activity name and it has changed, so I have submitted the code as an addition (not replacement) of the new name, that way it should work for people that don't update ans well as those that do.

Maybe you'd rather have just the new code?