### PR TITLE
Fixes appfilter drawable names of glsbank and ausweisapp

### DIFF
--- a/app/src/main/assets/appfilter.xml
+++ b/app/src/main/assets/appfilter.xml
@@ -535,8 +535,8 @@
     <!-- Auto Updater for Chromium -->
     <item component="ComponentInfo{com.dosse.chromiumautoupdater/com.dosse.chromiumautoupdater.MainActivity}" drawable="chromiumautoupdater" />
 
-	<!-- AusweisApp2 -->
-	<item component="ComponentInfo{com.governikus.ausweisapp2/com.governikus.ausweisapp2.MainActivity}" drawable="ausweisapp2"/>
+    <!-- AusweisApp2 -->
+    <item component="ComponentInfo{com.governikus.ausweisapp2/com.governikus.ausweisapp2.MainActivity}" drawable="ausweisapp"/>
 
     <!-- Avans One -->
     <item component="ComponentInfo{com.avans.oneapp/com.avans.oneapp.MainActivity}" drawable="avans" />
@@ -2242,8 +2242,8 @@
 	<!-- Glider -->
 	<item component="ComponentInfo{nl.viter.glider/nl.viter.glider.MainActivity}" drawable="glider"/>
 
-	<!-- GLS mBank -->
-	<item component="ComponentInfo{de.gls.mbank/subsembly.oemstarter.OEMActivity}" drawable="glsmbank"/>
+    <!-- GLS mBank -->
+    <item component="ComponentInfo{de.gls.mbank/subsembly.oemstarter.OEMActivity}" drawable="glsbank"/>
 
     <!-- Goblim -->
     <item component="ComponentInfo{fr.mobdev.goblim/fr.mobdev.goblim.activity.HistoryActivity}" drawable="goblim" />


### PR DESCRIPTION
The drawable names in the `appfilter.xml` were different than what the icons ended up being called. This PR fixes those associations.