### PR TITLE
Fix broken links for guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Maintaining this icon-pack costs a lot of time, besides making icons I'm curatin
 Making icons is fun and **you don't even have to know how to code**. Just install a vector graphic program like [Inkscape](https://inkscape.org/en/), Illustrator, Affinity Designer, [PenPot](https://penpot.app/) or [Vector Asset Creator](https://play.google.com/store/apps/details?id=com.inglesdivino.vectorassetcreator). 
 Read the full details here: 
 - [Contributing](CONTRIBUTING.md)
-- [Inkscape Guide](Inkscape_Guide.md)
-- [Vector Asset Creator guide](Vector_Asset_Creator.md)
+- [Inkscape Guide](guides/Inkscape_Guide.md)
+- [Vector Asset Creator guide](guides/Vector_Asset_Creator.md)
 
 **Come chat with us on Matrix:**
 


### PR DESCRIPTION
The links to the Inkscape and Vector Assest Creator guides are not pointing to them in [Readme.md](https://github.com/Donnnno/Arcticons/blob/main/README.md) 