### PR TITLE
[appfilter] icon changed: OAndBackupX

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -7168,7 +7168,9 @@
 
     <!-- Oandbackup -->
     <item component="ComponentInfo{dk.jens.backup/dk.jens.backup.OAndBackup}" drawable="oandbackup" />
-    <item component="ComponentInfo{com.machiav3lli.backup/com.machiav3lli.backup.activities.SplashActivity}" drawable="oandbackup" />
+
+    <!-- OAndBackupX -->
+     <item component="ComponentInfo{com.machiav3lli.backup/com.machiav3lli.backup.activities.SplashActivity}" drawable="oandbackupx"/>      
 
     <!-- Obedience -->
     <item component="ComponentInfo{com.obedience/com.obedience.settings.DefaultAlias}" drawable="obedience" />


### PR DESCRIPTION
The icon of [OAndBackupX](https://f-droid.org/en/packages/com.machiav3lli.backup/) is different from the icon of [oandbackup](https://f-droid.org/en/packages/dk.jens.backup/).

