### PR TITLE
Add main activity for SimpleReminder

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -449,11 +449,11 @@
     <!-- Adblock Plus für Samsung Internet -->
     <item component="ComponentInfo{org.adblockplus.adblockplussbrowser/org.adblockplus.sbrowser.contentblocker.MainPreferences}" drawable="adblock_plus_fur_samsung_internet" />
 
-    <!-- Add reminder -->
+    <!-- SimpleReminder -->
     <item component="ComponentInfo{felixwiemuth.simplereminder/felixwiemuth.simplereminder.ui.AddReminderDialogActivity}" drawable="letter_capital_r" />
-
-    <!-- Add reminder -->
     <item component="ComponentInfo{felixwiemuth.simplereminder/felixwiemuth.simplereminder.ui.AddReminderDialogActivity}" drawable="letter_uppercase_r" />
+    <item component="ComponentInfo{felixwiemuth.simplereminder/felixwiemuth.simplereminder.ui.reminderslist.RemindersListActivity}" drawable="letter_capital_r" />
+    <item component="ComponentInfo{felixwiemuth.simplereminder/felixwiemuth.simplereminder.ui.reminderslist.RemindersListActivity}" drawable="letter_uppercase_r" />
 
     <!-- Adidas Training -->
     <item component="ComponentInfo{com.runtastic.android.results.lite/com.runtastic.android.results.activities.LoginTourActivity}" drawable="adidas_training" />


### PR DESCRIPTION
The app provides two icons to click on.
One - which was already added - is a shortcut to immediately add a reminder, the other is the actual app.