### PR TITLE
Made all components fully formed

### DIFF
--- a/app/src/main/assets/appfilter.xml
+++ b/app/src/main/assets/appfilter.xml
@@ -1203,7 +1203,7 @@
     <item component="ComponentInfo{com.busydev.audiocutter/com.busydev.audiocutter.SplashActivity}" drawable="beetv" />
 
     <!-- Beelinguapp -->
-    <item component="ComponentInfo{com.david.android.languageswitch/com.david.android.languageswitch.ui.MainActivity" drawable="beelinguapp" />
+    <item component="ComponentInfo{com.david.android.languageswitch/com.david.android.languageswitch.ui.MainActivity}" drawable="beelinguapp" />
 
     <!-- Bee Brilliant -->
     <item component="ComponentInfo{dk.tactile.beebrilliant/dk.tactile.player.TactileActivityProxy}" drawable="beebrilliant" />
@@ -1720,7 +1720,7 @@
     <item component="ComponentInfo{org.geogebra.android.cascalc/org.geogebra.android.privatelibrary.splashscreen.SplashScreenActivity}" drawable="calcolatrice_cas" />
 
     <!-- Calctastic -->
-    <item component="com.shaytasticsoftware.calctasticfree/com.calctastic.android.CalcTasticActivity}" drawable="calctastic" />
+    <item component="ComponentInfo{com.shaytasticsoftware.calctasticfree/com.calctastic.android.CalcTasticActivity}" drawable="calctastic" />
 
     <!-- Calculator++ (Window mode) -->
     <item component="ComponentInfo{org.solovyev.android.calculator/org.solovyev.android.calculator.floating.FloatingCalculatorActivity}" drawable="calculatorpluspluswindowed" />
@@ -2266,7 +2266,7 @@
     <item component="ComponentInfo{com.viewer.comicscreen/com.viewer.comicscreen.ListActivity}" drawable="comicscreen" />
 
     <!-- Commons -->
-    <item component="fr.free.nrw.commons/fr.free.nrw.commons.auth.LoginActivity" drawable="commons" />
+    <item component="ComponentInfo{fr.free.nrw.commons/fr.free.nrw.commons.auth.LoginActivity}" drawable="commons" />
     <item component="ComponentInfo{fr.free.nrw.commons/fr.free.nrw.commons.auth.LoginActivity}" drawable="commons" />
 
     <!-- Common Voice -->
@@ -7826,7 +7826,7 @@
     <item component="ComponentInfo{com.symantec.cleansweep/com.symantec.cleansweep.app.SplashScreenActivity}" drawable="nortonclean" />
 
     <!-- Nosurf for Reddit -->
-    <item component="ComponentInfo{com.aaronhalbert.nosurfforreddit/com.aaronhalbert.nosurfforreddit.MainActivity" drawable="nosurfforreddit" />
+    <item component="ComponentInfo{com.aaronhalbert.nosurfforreddit/com.aaronhalbert.nosurfforreddit.MainActivity}" drawable="nosurfforreddit" />
     <item component="ComponentInfo{com.aaronhalbert.nosurfforreddit/com.aaronhalbert.nosurfforreddit.ui.main.MainActivity}" drawable="nosurfforreddit" />
 
     <!-- Notable -->
@@ -11571,7 +11571,7 @@
     <item component="ComponentInfo{com.stuff.todo/com.stuff.todo.activities.OrganizeActivity}" drawable="stuff" />
 
     <!-- Stumbler -->
-    <item component="org.mozilla.mozstumbler/org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity" drawable="stumbler" />
+    <item component="ComponentInfo{org.mozilla.mozstumbler/org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity}" drawable="stumbler" />
 
     <!-- Stuudium -->
     <item component="ComponentInfo{com.stuudium.app/com.stuudium.app.Stuudium}" drawable="letter_lowercase_s" />

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -1203,7 +1203,7 @@
     <item component="ComponentInfo{com.busydev.audiocutter/com.busydev.audiocutter.SplashActivity}" drawable="beetv" />
 
     <!-- Beelinguapp -->
-    <item component="ComponentInfo{com.david.android.languageswitch/com.david.android.languageswitch.ui.MainActivity" drawable="beelinguapp" />
+    <item component="ComponentInfo{com.david.android.languageswitch/com.david.android.languageswitch.ui.MainActivity}" drawable="beelinguapp" />
 
     <!-- Bee Brilliant -->
     <item component="ComponentInfo{dk.tactile.beebrilliant/dk.tactile.player.TactileActivityProxy}" drawable="beebrilliant" />
@@ -1720,7 +1720,7 @@
     <item component="ComponentInfo{org.geogebra.android.cascalc/org.geogebra.android.privatelibrary.splashscreen.SplashScreenActivity}" drawable="calcolatrice_cas" />
 
     <!-- Calctastic -->
-    <item component="com.shaytasticsoftware.calctasticfree/com.calctastic.android.CalcTasticActivity}" drawable="calctastic" />
+    <item component="ComponentInfo{com.shaytasticsoftware.calctasticfree/com.calctastic.android.CalcTasticActivity}" drawable="calctastic" />
 
     <!-- Calculator++ (Window mode) -->
     <item component="ComponentInfo{org.solovyev.android.calculator/org.solovyev.android.calculator.floating.FloatingCalculatorActivity}" drawable="calculatorpluspluswindowed" />
@@ -2266,7 +2266,7 @@
     <item component="ComponentInfo{com.viewer.comicscreen/com.viewer.comicscreen.ListActivity}" drawable="comicscreen" />
 
     <!-- Commons -->
-    <item component="fr.free.nrw.commons/fr.free.nrw.commons.auth.LoginActivity" drawable="commons" />
+    <item component="ComponentInfo{fr.free.nrw.commons/fr.free.nrw.commons.auth.LoginActivity}" drawable="commons" />
     <item component="ComponentInfo{fr.free.nrw.commons/fr.free.nrw.commons.auth.LoginActivity}" drawable="commons" />
 
     <!-- Common Voice -->
@@ -7826,7 +7826,7 @@
     <item component="ComponentInfo{com.symantec.cleansweep/com.symantec.cleansweep.app.SplashScreenActivity}" drawable="nortonclean" />
 
     <!-- Nosurf for Reddit -->
-    <item component="ComponentInfo{com.aaronhalbert.nosurfforreddit/com.aaronhalbert.nosurfforreddit.MainActivity" drawable="nosurfforreddit" />
+    <item component="ComponentInfo{com.aaronhalbert.nosurfforreddit/com.aaronhalbert.nosurfforreddit.MainActivity}" drawable="nosurfforreddit" />
     <item component="ComponentInfo{com.aaronhalbert.nosurfforreddit/com.aaronhalbert.nosurfforreddit.ui.main.MainActivity}" drawable="nosurfforreddit" />
 
     <!-- Notable -->
@@ -11571,7 +11571,7 @@
     <item component="ComponentInfo{com.stuff.todo/com.stuff.todo.activities.OrganizeActivity}" drawable="stuff" />
 
     <!-- Stumbler -->
-    <item component="org.mozilla.mozstumbler/org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity" drawable="stumbler" />
+    <item component="ComponentInfo{org.mozilla.mozstumbler/org.mozilla.mozstumbler.client.navdrawer.MainDrawerActivity}" drawable="stumbler" />
 
     <!-- Stuudium -->
     <item component="ComponentInfo{com.stuudium.app/com.stuudium.app.Stuudium}" drawable="letter_lowercase_s" />


### PR DESCRIPTION
Makes all components pass one of the following regex
- `ComponentInfo\{([^\/]+)\/([^}]+)\}`
- `ComponentInfo\{([^}]+)\}`

This allows stricter parsers to work with these lines instead of discarding them. My guess is that they are current malformed due to copy/paste errors