### PR TITLE
Fix NekoX App Icon activity name

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -8303,6 +8303,7 @@
 
     <!-- Nekogram X -->
     <item component="ComponentInfo{nekox.messenger/org.telegram.ui.LaunchActivity}" drawable="nekogramx" />
+    <item component="ComponentInfo{nekox.messenger/org.telegram.messenger.DefaultIcon}" drawable="nekogram_x"/>
     <item component="ComponentInfo{tw.nekomimi.nekogram/org.telegram.ui.LaunchActivity}" drawable="nekogramx" />
 
     <!-- Neko -->


### PR DESCRIPTION
With the introduction of Telegram Premium I suppose they have change the activity from
    `<item component="ComponentInfo{nekox.messenger/org.telegram.ui.LaunchActivity}" drawable="nekogramx" />`
to
   ` <item component="ComponentInfo{nekox.messenger/org.telegram.messenger.DefaultIcon}" drawable="nekogram_x"/>`

The previous versions have the activity name which was previously so I've just added this line below the original one.