### PR TITLE
Update Syphon Matrix client icon

### DIFF
--- a/app/src/main/res/xml/contributors.xml
+++ b/app/src/main/res/xml/contributors.xml
@@ -346,4 +346,9 @@
         contribution="Icon creator."
         image="https://avatars.githubusercontent.com/u/19829645?v=4"
         link="https://github.com/aliervo" />
+    <contributor
+        name="Grant Moyer"
+        contribution="Icon creator."
+        image="https://avatars.githubusercontent.com/u/6333127?v=4"
+        link="https://github.com/GrantMoyer" />
 </resources>

--- a/icons/black/syphon.svg
+++ b/icons/black/syphon.svg
@@ -1,1 +1,8 @@
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><defs><style>.cls-1{fill:none;stroke:#000;stroke-linecap:round;stroke-linejoin:round;}</style></defs><polygon class="cls-1" points="24 43.5 7.11 33.75 7.11 14.25 24 4.5 40.89 14.25 40.89 33.75 24 43.5"/><polygon class="cls-1" points="24 34.83 34.26 17.07 13.74 17.07 24 34.83"/><polygon class="cls-1" points="13.74 17.07 7.11 33.75 24 34.83 13.74 17.07"/><polygon class="cls-1" points="24 34.83 40.89 33.75 34.26 17.07 24 34.83"/><polygon class="cls-1" points="34.26 17.07 24 4.5 40.89 14.25 34.26 17.07"/><polygon class="cls-1" points="13.74 17.07 24 4.5 7.11 14.25 13.74 17.07"/><line class="cls-1" x1="24" y1="34.83" x2="24" y2="43.5"/><path class="cls-1" d="M7.11,33.75,24,43.5c-.06,0,0-8.67,0-8.67Z"/><path class="cls-1" d="M24,43.5S7.06,33.69,7.11,33.75v8.67Z"/></svg>
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <style type="text/css">.stroked {fill: none; stroke: #000; stroke-linecap: round; stroke-linejoin: round;}</style>
+  <path class="stroked" d="M 39.6981 16.7478 L 39.6981 29.874 C 39.6981 31.03 39.0815 32.0982 38.0807 32.6762 L 26.719 39.2377" />
+  <path class="stroked" d="M 14.1997 10.2046 L 22.3826 5.4789 C 23.3835 4.9009 24.6166 4.9009 25.6174 5.4789 L 36.7458 11.9056" />
+  <path class="stroked" d="M 21.281 39.2377 L 8.51101 31.8629" />
+  <path class="stroked" d="M 32.6362 28.8256 L 24.992 33.2518 C 24.3781 33.6072 23.6218 33.6072 23.008 33.2518 L 15.3637 28.8256 C 14.7499 28.4702 14.3717 27.8133 14.3717 27.1025 L 14.3717 18.2502 C 14.3717 17.5394 14.7499 16.8825 15.3637 16.527 L 23.008 12.1009 C 23.6218 11.7455 24.3781 11.7455 24.992 12.1009 L 32.6362 16.527 C 33.25 16.8825 33.6282 17.5394 33.6282 18.2502 L 33.6282 27.1025 C 33.6282 27.8133 33.25 28.4702 32.6362 28.8256 Z" />
+  <path class="stroked" d="m 8.3019299,13.799109 0,29.319386 12.9790811,-1.910368" />
+</svg>

--- a/icons/white/syphon.svg
+++ b/icons/white/syphon.svg
@@ -1,1 +1,8 @@
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><defs><style>.cls-1{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;}</style></defs><polygon class="cls-1" points="24 43.5 7.11 33.75 7.11 14.25 24 4.5 40.89 14.25 40.89 33.75 24 43.5"/><polygon class="cls-1" points="24 34.83 34.26 17.07 13.74 17.07 24 34.83"/><polygon class="cls-1" points="13.74 17.07 7.11 33.75 24 34.83 13.74 17.07"/><polygon class="cls-1" points="24 34.83 40.89 33.75 34.26 17.07 24 34.83"/><polygon class="cls-1" points="34.26 17.07 24 4.5 40.89 14.25 34.26 17.07"/><polygon class="cls-1" points="13.74 17.07 24 4.5 7.11 14.25 13.74 17.07"/><line class="cls-1" x1="24" y1="34.83" x2="24" y2="43.5"/><path class="cls-1" d="M7.11,33.75,24,43.5c-.06,0,0-8.67,0-8.67Z"/><path class="cls-1" d="M24,43.5S7.06,33.69,7.11,33.75v8.67Z"/></svg>
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <style type="text/css">.stroked {fill: none; stroke: #fff; stroke-linecap: round; stroke-linejoin: round;}</style>
+  <path class="stroked" d="M 39.6981 16.7478 L 39.6981 29.874 C 39.6981 31.03 39.0815 32.0982 38.0807 32.6762 L 26.719 39.2377" />
+  <path class="stroked" d="M 14.1997 10.2046 L 22.3826 5.4789 C 23.3835 4.9009 24.6166 4.9009 25.6174 5.4789 L 36.7458 11.9056" />
+  <path class="stroked" d="M 21.281 39.2377 L 8.51101 31.8629" />
+  <path class="stroked" d="M 32.6362 28.8256 L 24.992 33.2518 C 24.3781 33.6072 23.6218 33.6072 23.008 33.2518 L 15.3637 28.8256 C 14.7499 28.4702 14.3717 27.8133 14.3717 27.1025 L 14.3717 18.2502 C 14.3717 17.5394 14.7499 16.8825 15.3637 16.527 L 23.008 12.1009 C 23.6218 11.7455 24.3781 11.7455 24.992 12.1009 L 32.6362 16.527 C 33.25 16.8825 33.6282 17.5394 33.6282 18.2502 L 33.6282 27.1025 C 33.6282 27.8133 33.25 28.4702 32.6362 28.8256 Z" />
+  <path class="stroked" d="m 8.3019299,13.799109 0,29.319386 12.9790811,-1.910368" />
+</svg>


### PR DESCRIPTION
Syphon icon was still based on the old icosahedron icon. This change updates the icon to be more in line with Syphon's current official icon.

See https://github.com/syphon-org/syphon/commit/28e05bc73adb3de9f16a283c85aea853ae9f34d2

Rendered:

| Existing | Updated |
|:----:|:----:|
| ![syphon exisiting](https://user-images.githubusercontent.com/6333127/188182119-4dec0d95-a05e-41f0-be5e-3166a79f6e83.png) | ![syphon updated](https://user-images.githubusercontent.com/6333127/188181713-76f85f44-eb97-494a-9d5e-e8abdb648288.png) |
