### PR TITLE
Add icon: Führerschein / theorie24

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -4763,6 +4763,12 @@
     <!-- Fuel Flash -->
     <item component="ComponentInfo{de.mwwebwork.benzinpreisblitz/de.mwwebwork.benzinpreisblitz.MainActivity}" drawable="fuelflash" />
 
+    <!-- Füherschein -->
+    <item component="ComponentInfo{de.theorie24.fs.auto/de.theorie24.fs.auto.MainActivity}" drawable="theorie24" />
+    <item component="ComponentInfo{de.theorie24.fs.mofa/de.theorie24.fs.mofa.MainActivity}" drawable="theorie24" />
+    <item component="ComponentInfo{de.theorie24.fs.multilingual/de.theorie24.fs.multilingual.MainActivity}" drawable="theorie24" />
+    <item component="ComponentInfo{de.theorie24.fs.multilingualpro/de.theorie24.fs.multilingualpro.MainActivity}" drawable="theorie24" />
+
     <!-- Function Generator -->
     <item component="ComponentInfo{com.keuwl.functiongenerator/com.keuwl.functiongenerator.MainActivity}" drawable="functiongenerator" />
 

--- a/other/theorie24.svg
+++ b/other/theorie24.svg
@@ -1,0 +1,20 @@
+<svg version="1.1" viewBox="0 0 48 48"
+    xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <style>.a{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;}</style>
+    </defs>
+    <g fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="16.479" y="5.4987" width="15.043" height="37.003" stroke-width=".95717"/>
+        <path d="m16.5 17.5h-1.5l-8-8h9.5" stroke-linecap="butt"/>
+        <circle cx="24" cy="13.5" r="4"/>
+        <circle cx="24" cy="24" r="4"/>
+        <circle cx="24" cy="34.5" r="4"/>
+        <g stroke-linecap="butt">
+            <path d="m16.5 28h-1.5l-8-8h9.5"/>
+            <path d="m16.5 38.5h-1.5l-8-8h9.5"/>
+            <path d="m31.5 17.5h1.5l8-8h-9.5"/>
+            <path d="m31.5 28h1.5l8-8h-9.5"/>
+            <path d="m31.5 38.5h1.5l8-8h-9.5"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This is my third icon.
I suggest using it for [all "Führerschein" apps by _theorie24_](https://play.google.com/store/apps/developer?id=theorie24+GmbH+-+Deutschland),
but I didn't verify the appfilter for all these apps, 
since most are paid.

Here's the app I did the icon request on:
> Führerschein
> de.theorie24.fs.mofa/de.theorie24.fs.mofa.MainActivity
> https://play.google.com/store/apps/details?id=de.theorie24.fs.mofa
