### PR TITLE
Add theme support for Lawnchair Launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -164,6 +164,11 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+             <!-- Lawnchair Launcher -->
+            <intent-filter>
+                <action android:name="app.lawnchair.icons.THEMED_ICON" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
             <!-- Lawnchair -->
             <intent-filter>
                 <action android:name="ch.deletescape.lawnchair.ICONPACK" />


### PR DESCRIPTION
Now Lawnchair added theme support for third part icon pack [3116](https://github.com/LawnchairLauncher/lawnchair/pull/3116) , icon pack who provides adaptive icon or any icon pack with black foreground and transparent background can easily support dynamic theme.

Sample after applying theme in lawnchair

https://user-images.githubusercontent.com/7315975/202911172-cc5e39a6-e36b-4d53-ac30-692d2e7c1285.mp4

Dev build to support this feature.

https://github.com/LawnchairLauncher/lawnchair/actions/runs/3508261966
