### PR TITLE
Add icon metadata for all versions of shuttle

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -11993,8 +11993,14 @@
     <!-- Shrug ¯\_(ツ)_/¯ -->
     <item component="ComponentInfo{com.codebutler.shrug/com.codebutler.shrug.MainActivity}" drawable="shrug" />
 
+    <!-- Shuttle -->
+    <item component="ComponentInfo{another.music.player/com.simplecity.amp_library.ui.activities.MainActivity}" drawable="shuttle" />
+
     <!-- Shuttle+ -->
     <item component="ComponentInfo{com.simplecity.amp_pro/com.simplecity.amp_library.ui.activities.MainActivity}" drawable="shuttle" />
+
+    <!-- Shuttle 2 -->
+    <item component="ComponentInfo{com.simplecityapps.shuttle/com.simplecityapps.shuttle.ui.MainActivity}" drawable="shuttle" />
 
     <!-- SicMu Player -->
     <item component="ComponentInfo{souch.smp/souch.smp.Main}" drawable="sicmu_player" />


### PR DESCRIPTION
Add icon metadata to reuse the icon used for Shuttle+ for both Shuttle and Shuttle 2