### PR TITLE
Update appfilter.xml

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -2274,6 +2274,7 @@
 
     <!-- Bromite -->
     <item component="ComponentInfo{org.bromite.bromite/com.google.android.apps.chrome.Main}" drawable="bromite" />
+    <item component="ComponentInfo{org.bromite.bromite/org.chromium.chrome.browser.ChromeTabbedActivity}" drawable="bromite"/>
 
     <!-- Browser -->
     <item component="ComponentInfo{foundation.e.browser/com.google.android.apps.chrome.Main}" drawable="browser" />


### PR DESCRIPTION
Icon for Bromite doesn't show in recents screen (unlike other apps). It seems the activities differ for the launcher and while in use.

Found the right activity class using adb and appended to the current entry. If this doesn't work, I'll make another PR to revert the changes.