### PR TITLE
Fix a couple of oddities in appfilter.xml

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -7892,7 +7892,7 @@
   <item component="ComponentInfo{com.draco.ktweak/com.draco.ktweak.activities.MainActivity}" drawable="ktweak"/>
 
   <!-- Kubenav -->
-  <item component="ComponentInfo{ io.kubenav.kubenav/io.kubenav.kubenav.MainActivity}" drawable="kubenav"/>
+  <item component="ComponentInfo{io.kubenav.kubenav/io.kubenav.kubenav.MainActivity}" drawable="kubenav"/>
 
   <!-- KuCoin -->
   <item component="ComponentInfo{com.kubi.kucoin/com.kubi.kucoin.feature.SplashActivity}" drawable="kucoin"/>
@@ -10917,7 +10917,7 @@
 
   <!-- OPENREC.tv -->
   <item component="ComponentInfo{jp.co.cyber_z.openrecviewapp/jp.co.cyber_z.openrecviewapp.feature.discover.ui.top.TopActivity}" drawable="openrectv"/>
-  <item component="ComponentInfo{ jp.co.cyber_z.openrecviewapp/jp.co.cyber_z.openrecviewapp.feature.main.ui.MainActivity}" drawable="openrectv"/>
+  <item component="ComponentInfo{jp.co.cyber_z.openrecviewapp/jp.co.cyber_z.openrecviewapp.feature.main.ui.MainActivity}" drawable="openrectv"/>
 
   <!-- OpenScale -->
   <item component="ComponentInfo{com.health.openscale/com.health.openscale.gui.MainActivity}" drawable="openscale"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -72,7 +72,7 @@
   <item component="ComponentInfo{org.xbet.client.bitcoin/org.xbet.client1.new_arch.presentation.ui.starter.StarterActivity}" drawable="_1xbit"/>
 
   <!-- 2 Player Games -->
-  <item component="ComponentInfo{com.JindoBlu.TwoPlayerGamesChallenge/com.unity3d.player.UnityPlayerActivity}" drawable="2_player_games"/>
+  <item component="ComponentInfo{com.JindoBlu.TwoPlayerGamesChallenge/com.unity3d.player.UnityPlayerActivity}" drawable="_2_player_games"/>
 
   <!-- 2048 -->
   <item component="ComponentInfo{com.uberspot.a2048/com.uberspot.a2048.MainActivity}" drawable="_2048"/>
@@ -238,7 +238,7 @@
   <item component="ComponentInfo{com.foxdebug.acodefree/com.foxdebug.acodefree.MainActivity}" drawable="acode"/>
 
   <!-- Acorns -->
-  <item component="ComponentInfo(com.acorns.androic/com.acorns.android.splash.SplashActivity)" drawable="acorns"/>
+  <item component="ComponentInfo{com.acorns.androic/com.acorns.android.splash.SplashActivity}" drawable="acorns"/>
 
   <!-- ACR Phone -->
   <item component="ComponentInfo{com.nll.cb/com.nll.cb.RouterActivity}" drawable="phone"/>
@@ -4716,7 +4716,7 @@
   <item component="ComponentInfo{com.delan.app.germanybluetooth/com.delan.app.germanybluetooth.bluetooth.WelcomeActivity}" drawable="letter_uppercase_e"/>
 
   <!-- EVE Portal -->
-  <item component="ComponentInfo(com.ccpgames.eveportal2android/com.google.firebase.MessagingUnityPlayerActivity)" drawable="eve_portal"/>
+  <item component="ComponentInfo{com.ccpgames.eveportal2android/com.google.firebase.MessagingUnityPlayerActivity}" drawable="eve_portal"/>
 
   <!-- Event Radar -->
   <item component="ComponentInfo{org.radar.app/org.qtproject.qt5.android.bindings.QtActivity}" drawable="event_radar"/>
@@ -6413,7 +6413,7 @@
   <item component="ComponentInfo{org.billthefarmer.gurgle/org.billthefarmer.gurgle.Gurgle}" drawable="gurgle"/>
 
   <!-- Gwent -->
-  <item component="ComponentInfo(com.cdprojektred.gwent/com.cdprojektred.androidbridge.PluginControllerActivity)" drawable="gwent"/>
+  <item component="ComponentInfo{com.cdprojektred.gwent/com.cdprojektred.androidbridge.PluginControllerActivity}" drawable="gwent"/>
 
   <!-- Gyan Fresh -->
   <item component="ComponentInfo{com.gyandairy/com.app.gyandiarycustomer.register.ui.SplashActivity}" drawable="gyanfresh"/>
@@ -6913,7 +6913,7 @@
   <item component="ComponentInfo{de.hochbahn.hvvswitch/de.hochbahn.hvvswitch.ui.splash.SplashActivity}" drawable="hvv_switch"/>
 
   <!-- Hy-Vee -->
-  <item component="ComponentInfo(com.hyvee.grocery/com.hyvee.SplashActivity)" drawable="hyvee"/>
+  <item component="ComponentInfo{com.hyvee.grocery/com.hyvee.SplashActivity}" drawable="hyvee"/>
 
   <!-- Hydro-Quebec -->
   <item component="ComponentInfo{com.hydroquebec.mf_android/com.hydroquebec.mf_android.MainActivity}" drawable="hydro_quebec"/>
@@ -7883,7 +7883,7 @@
   <item component="ComponentInfo{org.krita/org.krita.android.MainActivity}" drawable="krita"/>
 
   <!-- Kroger -->
-  <item component="ComponentInfo(com.kroger.mobile/com.kroger.mobile.BannerSelectionActivity)" drawable="kroger"/>
+  <item component="ComponentInfo{com.kroger.mobile/com.kroger.mobile.BannerSelectionActivity}" drawable="kroger"/>
 
   <!-- KSync -->
   <item component="ComponentInfo{com.infomaniak.sync/at.bitfire.davdroid.ui.AccountsActivity}" drawable="ksync"/>
@@ -17689,7 +17689,7 @@
   <item component="ComponentInfo{com.able.wisdomtree/com.able.wisdomtree.jpush.OutLineActivity}" drawable="zhihuishu_treenity"/>
 
   <!-- Zillow Rental -->
-  <item component="ComponentInfo(com.zillow.android.rentals/com.zillow.android.re.ui.SplashScreenActivity)" drawable="zillow"/>
+  <item component="ComponentInfo{com.zillow.android.rentals/com.zillow.android.re.ui.SplashScreenActivity}" drawable="zillow"/>
 
   <!-- Zlib -->
   <item component="ComponentInfo{com.positron_it.zlib/com.positron_it.zlib.ui.splash.SplashActivity}" drawable="zlib"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -9866,7 +9866,7 @@
 
   <!-- MyJio -->
   <item component="ComponentInfo{com.jio.myjio/com.jio.myjio.dashboard.activities.DashboardActivity}" drawable="myjio"/>
-  <item component="ComponentInfo{ com.jio.myjio/com.jio.myjio.dashboard.activities.SplashActivity}" drawable="myjio"/>
+  <item component="ComponentInfo{com.jio.myjio/com.jio.myjio.dashboard.activities.SplashActivity}" drawable="myjio"/>
 
   <!-- MyMail -->
   <item component="ComponentInfo{com.my.mail/ru.mail.mailapp.SplashScreenActivity}" drawable="mymail"/>


### PR DESCRIPTION
I don't know why several entries used regular parenthesis instead of the curly braces, but it tripped up my script. The drawable `_2_player_games.svg` exists in the `/icon/black`, but was misnamed here. I'm assuming this'll fix the app icon (it should be broken right now).

The changes are entirely untested, as my use-case for the file is different from the regular icon pack.