### PR TITLE
Added icon for ShareNow app and fixed one component name

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -7805,6 +7805,9 @@
 	<!-- Freenet Mobile -->
 	<item component="ComponentInfo{org.freenetproject.mobile/org.freenetproject.mobile.ui.main.activity.MainActivity}" drawable="freenet_mobile"/>
 
+	<!-- Free Now -->
+	<item component="ComponentInfo{taxi.android.client/taxi.android.client.feature.startup.ui.StartupActivity}" drawable="share_now"/>
+
 	<!-- FreeOTP -->
 	<item component="ComponentInfo{org.fedorahosted.freeotp/org.fedorahosted.freeotp.MainActivity}" drawable="freeotp"/>
 	<item component="ComponentInfo{org.fedorahosted.freeotp/org.fedorahosted.freeotp.PasswordActivity}" drawable="freeotp"/>
@@ -18274,6 +18277,9 @@
 	<!-- ShareMe -->
 	<item component="ComponentInfo{com.xiaomi.midrop/com.xiaomi.midrop.SplashScreen}" drawable="shareme"/>
 
+	<!-- Share Now -->
+	<item component="ComponentInfo{com.car2go/activity.MainActivity}" drawable="share_now"/>
+
 	<!-- Sharik -->
 	<item component="ComponentInfo{dev.marchello.sharik/dev.marchello.sharik.MainActivity}" drawable="sharik"/>
 	<item component="ComponentInfo{dev.monora.sharik/dev.monora.sharik.MainActivity}" drawable="sharik"/>
@@ -19936,6 +19942,7 @@
 
 	<!-- SSB Flex -->
 	<item component="ComponentInfo{ssb.flex/via.rider.activities.HomeActivity}" drawable="ssb_flex"/>
+	<item component="ComponentInfo{ssb.flex/via.rider.features.splash.SplashActivityKt}" drawable="ssb_flex"/>
 
 	<!-- SSB Move -->
 	<item component="ComponentInfo{de.eos.uptrade.android.fahrinfo.stuttgart/de.eos.uptrade.android.fahrinfo.activity.tabs.MainTabActivity}" drawable="ssb_move"/>

--- a/other/share_now.svg
+++ b/other/share_now.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 48 48"><defs><style>.a{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round}</style></defs><path class="a" d="m8 14 11 8v13l21-21"/></svg>

--- a/other/share_now.svg
+++ b/other/share_now.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 48 48"><defs><style>.a{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round}</style></defs><path class="a" d="m8 14 11 8v13l21-21"/></svg>
+<?xml version="1.0" encoding="UTF-8"?><svg id="a" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><defs><style>.b{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path class="b" d="m4.5,11.7031l13.4062,9.75v15.8438l25.5938-25.5938"/></svg>


### PR DESCRIPTION
- The icon is also shared with the FreeNow app so I added this as well. (The FreeNow app actually has a different background color so I didn't know how to accomodate for that. I think it is okay if they share the same icon.)
- The SSBFlex app I contributed [here](https://github.com/Donnnno/Arcticons/pull/1685) changed its main activity name

Preview of the new icon:
![icon_preview](https://github.com/Donnnno/Arcticons/assets/44189118/5508901a-e124-4f96-9eda-b2524e7103e0)