### PR TITLE
Update nationwide icon to match new logo

### DIFF
--- a/other/nationwide.svg
+++ b/other/nationwide.svg
@@ -1,16 +1,1 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   id="b"
-   viewBox="0 0 48 48"
-   version="1.1"
-   xml:space="preserve"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><defs
-     id="defs4"><style
-       id="style2">.c{fill:none;stroke:#000;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path
-     style="stroke-width:1;fill:none;stroke:#ffffff;stroke-opacity:1;stroke-dasharray:none;stroke-linejoin:round;stroke-linecap:round"
-     d="M 24.74729,44.367229 H 45.236261 V 30.960033 L 34.965874,18.765081 24.742111,30.960033 v 13.407196 h 0.0078 z"
-     id="path810" /><path
-     style="stroke-width:1;stroke-dasharray:none;stroke:#ffffff;stroke-opacity:1;fill:none;stroke-linejoin:round;stroke-linecap:round"
-     d="M 34.971054,18.762491 C 34.460772,10.341549 27.41267,3.6327711 18.914021,3.6327711 c -8.9156809,0 -16.1502824,7.1698449 -16.1502824,16.1062479 0,4.281703 1.67849,8.242214 4.5277776,11.130356 L 17.934902,18.762491 h 17.038743 z"
-     id="path492" /></svg>
+<?xml version="1.0" encoding="UTF-8"?><svg id="a" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><defs><style>.d{fill:none;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path id="b" class="d" d="m24.651,41.7429h17.849v-11.6797l-8.9471-10.6237-8.9064,10.6237v11.6797h.0068-.0023Z"/><path id="c" class="d" d="m33.5575,19.4373c-.4445-7.3359-6.5845-13.1803-13.9881-13.1803-7.7669,0-14.0693,6.246-14.0693,14.031,0,3.73,1.4622,7.1802,3.9444,9.6962l9.272-10.5469h14.8433-.0023Z"/></svg>

--- a/other/nationwide.svg
+++ b/other/nationwide.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="b"
+   viewBox="0 0 48 48"
+   version="1.1"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs4"><style
+       id="style2">.c{fill:none;stroke:#000;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path
+     style="stroke-width:1;fill:none;stroke:#ffffff;stroke-opacity:1;stroke-dasharray:none;stroke-linejoin:round;stroke-linecap:round"
+     d="M 24.74729,44.367229 H 45.236261 V 30.960033 L 34.965874,18.765081 24.742111,30.960033 v 13.407196 h 0.0078 z"
+     id="path810" /><path
+     style="stroke-width:1;stroke-dasharray:none;stroke:#ffffff;stroke-opacity:1;fill:none;stroke-linejoin:round;stroke-linecap:round"
+     d="M 34.971054,18.762491 C 34.460772,10.341549 27.41267,3.6327711 18.914021,3.6327711 c -8.9156809,0 -16.1502824,7.1698449 -16.1502824,16.1062479 0,4.281703 1.67849,8.242214 4.5277776,11.130356 L 17.934902,18.762491 h 17.038743 z"
+     id="path492" /></svg>


### PR DESCRIPTION
Nationwide Building Society (nationwide.co.uk) updated their logo: this updates the icon to match.