### PR TITLE
Update & Extend Coverage

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -12634,6 +12634,7 @@
 
 	<!-- LanDroid -->
 	<item component="ComponentInfo{net.fidanov.landroid/net.fidanov.landroid.main}" drawable="landroid"/>
+	<item component="ComponentInfo{de.dieterthiess.ipwidget/de.dieterthiess.ipwidget.SettingsActivity}" drawable="landroid"/>
 
 	<!-- Lang Easy Lexis -->
 	<item component="ComponentInfo{cn.com.langeasy.LangEasyLexis/cn.com.langeasy.LangEasyLexis.activity.SplashActivity}" drawable="langeasylexis"/>
@@ -18659,6 +18660,8 @@
 
 	<!-- Power App -->
 	<item component="ComponentInfo{io.github.domi04151309.powerapp/io.github.domi04151309.powerapp.activities.SplashActivity}" drawable="powerapp"/>
+	<item component="ComponentInfo{com.kieronquinn.app.classicpowermenu/com.kieronquinn.app.classicpowermenu.ui.activities.MainActivit}" drawable="powerapp"/>
+	<item component="ComponentInfo{com.urbandroid.ddc/com.urbandroid.ddc.activity.TourActivity}" drawable="powerapp"/>	
 
 	<!-- Power Buy -->
 	<item component="ComponentInfo{com.powerbuy.mobile/com.powerbuy.mobile.presentation.MainActivity}" drawable="power_buy"/>
@@ -18990,6 +18993,7 @@
 
 	<!-- Pulse SMS -->
 	<item component="ComponentInfo{xyz.klinker.messenger/xyz.klinker.messenger.activity.MessengerActivity}" drawable="pulsesms"/>
+	<item component="ComponentInfo{com.crossbowffs.nekosms/com.crossbowffs.nekosms.app.MainActivity}" drawable="pulsesms"/>	
 
 	<!-- PulseAudio Rtp Receiver -->
 	<item component="ComponentInfo{me.wenxinwang.pulsedroidrtp/me.wenxinwang.pulsedroidrtp.MainActivity}" drawable="pulseaudiortpreceiver"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -3180,6 +3180,7 @@
 
 	<!-- Bixby Vision -->
 	<item component="ComponentInfo{com.samsung.android.visionintelligence/com.samsung.android.visionintelligence.main.DummyActivity}" drawable="bixby_vision"/>
+	<item component="ComponentInfo{com.zacharee1.insomnia/com.zacharee1.insomnia.LauncherActivity}" drawable="bixby_vision"/>
 
 	<!-- BİM -->
 	<item component="ComponentInfo{com.bim.market/com.bim.market.SplashActivity}" drawable="bim"/>
@@ -12572,6 +12573,8 @@
 	<!-- KWGT -->
 	<item component="ComponentInfo{org.kustom.widget/org.kustom.widget.picker.WidgetPicker}" drawable="kwgt"/>
 	<item component="ComponentInfo{org.kustom.wallpaper/org.kustom.app.OnBoardingActivity}" drawable="kwgt"/>
+	<item component="ComponentInfo{org.kustom.lockscreen/org.kustom.app.OnBoardingActivity}" drawable="kwgt"/>
+	<item component="ComponentInfo{org.kustom.weather/org.kustom.weather.MainActivity}" drawable="kwgt"/>	
 
 	<!-- KWGT Pro -->
 	<item component="ComponentInfo{org.kustom.widget.pro/org.kustom.pro.MainActivity}" drawable="kwgt_pro"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -13389,6 +13389,7 @@
 
 	<!-- LSPosed -->
 	<item component="ComponentInfo{org.lsposed.manager/org.lsposed.manager.ui.activity.MainActivity}" drawable="lsposed"/>
+	<item component="ComponentInfo{com.android.shell/com.android.shell.android.app.AppDetailsActivity}" drawable="lsposed"/>	
 
 	<!-- LTE Cleaner -->
 	<item component="ComponentInfo{theredspy15.ltecleanerfoss/theredspy15.ltecleanerfoss.MainActivity}" drawable="ltecleaner"/>
@@ -22972,6 +22973,9 @@
 
 	<!-- Sugarizer -->
 	<item component="ComponentInfo{org.olpc_france.sugarizer/org.olpc_france.sugarizer.MainActivity}" drawable="sugarizer"/>
+
+	<!-- Sui -->
+	<item component="ComponentInfo{com.android.settings/com.android.settings.Settings}" drawable="apk_explorer_and_editor_alt"/>
 
 	<!-- SuisseMobile -->
 	<item component="ComponentInfo{ch.schweizmobil/ch.schweizmobil.map.MapActivity}" drawable="suissemobile"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -10376,6 +10376,8 @@
 
 	<!-- Hanping Lite -->
 	<item component="ComponentInfo{com.embermitre.hanping.app.lite/com.embermitre.dictroid.ui.SearchActivity}" drawable="hanping_lite"/>
+	<item component="ComponentInfo{com.embermitre.hanping.app.pro/com.embermitre.dictroid.ui.SearchActivity}" drawable="hanping_lite"/>
+	<item component="ComponentInfo{com.embermitre.hanping.cantodict.app.pro/com.embermitre.dictroid.ui.SearchActivity}" drawable="hanping_lite"/>
 
 	<!-- Hanseatic Bank Mobile -->
 	<item component="ComponentInfo{com.hanseaticbank.banking/com.hanseaticbank.banking.MainActivity}" drawable="bank_1"/>
@@ -19989,6 +19991,7 @@
 
 	<!-- RootlessJamesDSP -->
 	<item component="ComponentInfo{me.timschneeberger.rootlessjamesdsp/me.timschneeberger.rootlessjamesdsp.activity.MainActivity}" drawable="rootlessjamesdsp"/>
+	<item component="ComponentInfo{james.dsp/me.timschneeberger.rootlessjamesdsp.activity.MainActivity}" drawable="rootlessjamesdsp"/>
 
 	<!-- Rosetta Stone -->
 	<item component="ComponentInfo{air.com.rosettastone.mobile.CoursePlayer/com.rosettastone.MainActivity}" drawable="rosetta_stone"/>
@@ -20605,6 +20608,7 @@
 
 	<!-- Security -->
 	<item component="ComponentInfo{com.miui.securitycenter/com.miui.securityscan.MainActivity}" drawable="security"/>
+	<item component="ComponentInfo{github.tornaco.android.thanos/github.tornaco.android.thanos.main.NavActivity}" drawable="security"/>	
 
 	<!-- SecurityBank -->
 	<item component="ComponentInfo{com.securitybank/com.securitybank.activity.SplashActivity}" drawable="securitybank"/>
@@ -22951,6 +22955,8 @@
 	<item component="ComponentInfo{org.benoitharrault.sudoku/org.benoitharrault.sudoku.MainActivity}" drawable="sudokuoss"/>
 	<item component="ComponentInfo{com.app2go.sudokufree/com.app2go.sudokufree.MainActivity}" drawable="sudokufree"/>
 	<item component="ComponentInfo{com.easybrain.sudoku.android/com.easybrain.template.SplashActivity}" drawable="sudoku"/>
+	<item component="ComponentInfo{com.andoku.three.gp/com.andoku.app.LaunchActivity}" drawable="sudoku"/>
+	<item component="ComponentInfo{com.andoku.two.full/com.andoku.LaunchActivity}" drawable="sudoku"/>	
 
 	<!-- SudoQ -->
 	<item component="ComponentInfo{de.sudoq/de.sudoq.controller.menus.SplashActivity}" drawable="sudoq"/>
@@ -23021,6 +23027,7 @@
 
 	<!-- SuperImage -->
 	<item component="ComponentInfo{com.zhenxiang.superimage/com.zhenxiang.superimage.MainActivity}" drawable="letter_uppercase_square_s"/>
+	<item component="ComponentInfo{com.zhenxiang.superimage.pro/com.zhenxiang.superimage.MainActivity}" drawable="letter_uppercase_square_s"/>	
 
 	<!-- SuperMemo -->
 	<item component="ComponentInfo{com.supermemo/com.supermemo.uiContainer.ui.splash.SplashActivity}" drawable="supermemo"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -2867,6 +2867,7 @@
 
 	<!-- Better Open With -->
 	<item component="ComponentInfo{com.aboutmycode.betteropenwith/com.aboutmycode.betteropenwith.HandlerListActivity}" drawable="better_open_with"/>
+	<item component="ComponentInfo{com.rejh.sharedr/com.rejh.sharedr.ActMain}" drawable="better_open_with"/>
 
 	<!-- Better schedule -->
 	<item component="ComponentInfo{cz.vitskalicky.lepsirozvrh/cz.vitskalicky.lepsirozvrh.activity.MainActivity}" drawable="betterschedule"/>
@@ -9668,6 +9669,7 @@
 
 	<!-- GLS -->
 	<item component="ComponentInfo{dk.gls.consigneeapp/crc643fee848a06ac8388.MainActivity}" drawable="gls"/>
+	<item component="ComponentInfo{com.gls.glsappde.consumer/de.gls.features.main.MainActivity}" drawable="gls"/>
 
 	<!-- GLS Banking -->
 	<item component="ComponentInfo{de.gls.banking.app/de.visualvest.gls.MainActivity}" drawable="gls_banking"/>
@@ -12083,6 +12085,7 @@
 
 	<!-- Kasts -->
 	<item component="ComponentInfo{org.kde.kasts/org.qtproject.qt5.android.bindings.QtActivity}" drawable="kasts"/>
+	<item component="ComponentInfo{dev.zwander.cellreader/dev.zwander.cellreader.MainActivity}" drawable="kasts"/>
 
 	<!-- Kate Mobile -->
 	<item component="ComponentInfo{com.perm.kate/com.perm.kate.InitialActivity}" drawable="letter_uppercase_square_k"/>
@@ -16061,6 +16064,7 @@
 
 	<!-- Neumorphic Calculator -->
 	<item component="ComponentInfo{com.neumorphic.calculator/com.neumorphic.calculator.MainActivity}" drawable="neumorphic_calculator"/>
+	<item component="ComponentInfo{com.andoku.calcudoku/calc.app.LaunchActivity}" drawable="neumorphic_calculator"/>
 
 	<!-- Neural Cloud -->
 	<item component="ComponentInfo{com.sunborn.neuralcloud.en/com.sunborn.neuralcloud.en.GameMainActivity}" drawable="neural_cloud"/>
@@ -21985,6 +21989,7 @@
 
 	<!-- Skype -->
 	<item component="ComponentInfo{com.skype.raider/com.skype4life.MainActivity}" drawable="skype"/>
+	<item component="ComponentInfo{com.skype.insiders/com.skype4life.MainActivity}" drawable="skype"/>	
 
 	<!-- Skype Lite -->
 	<item component="ComponentInfo{com.skype.m2/com.skype.m2.views.HubActivity}" drawable="skype"/>
@@ -26246,6 +26251,8 @@
 
 	<!-- Webtoon -->
 	<item component="ComponentInfo{com.naver.linewebtoon/com.naver.linewebtoon.splash.SplashActivity}" drawable="webtoon"/>
+	<item component="ComponentInfo{com.nhn.android.webtoon/com.naver.webtoon.splash.SplashActivity}" drawable="webtoon"/>
+	<item component="ComponentInfo{net.daum.android.webtoon/net.daum.android.WebtoonActivity}" drawable="webtoon"/>	
 
 	<!-- WebTube -->
 	<item component="ComponentInfo{cz.martykan.webtube/cz.martykan.webtube.MainActivity}" drawable="youtube"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -11521,7 +11521,7 @@
 	<item component="ComponentInfo{com.codelv.inventory/com.codelv.inventory.MainActivity}" drawable="inventory"/>
 
 	<!-- Inventory -->
-	<item component="ComponentInfo{net.twisterrob.inventory/net.twisterrob.inventory.android.activity.MainActivity}" drawable="inventory"/>
+	<item component="ComponentInfo{net.twisterrob.inventory/net.twisterrob.inventory.android.activity.MainActivity}" drawable="inventory_og"/>
 
 	<!-- Invest -->
 	<item component="ComponentInfo{com.starfinanz.mobile.android.invest/de.starfinanz.sdepot.launch.MainActivity}" drawable="invest"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -740,6 +740,7 @@
 
 	<!-- AIDE -->
 	<item component="ComponentInfo{com.aide.ui/com.aide.ui.MainActivity}" drawable="aide"/>
+	<item component="ComponentInfo{com.google.samples.apps.nowinandroid/com.google.samples.apps.nowinandroid.MainActivity}" drawable="aide"/>
 
 	<!-- AIDS -->
 	<item component="ComponentInfo{com.nick80835.add/com.nick80835.add.MainActivity}" drawable="aids"/>
@@ -1360,6 +1361,8 @@
 
 	<!-- Android Version -->
 	<item component="ComponentInfo{com.github.mueller_ma.viewandroidversion/com.github.mueller_ma.viewandroidversion.MainActivity}" drawable="android"/>
+	<item component="ComponentInfo{io.github.muntashirakon.captiveportalcontroller/io.github.muntashirakon.captiveportalcontroller.LaunchActivity}" drawable="android"/>
+	<item component="ComponentInfo{lsposed.orange/lsposed.orange.Launcher}" drawable="android"/>
 
 	<!-- AndroidRun -->
 	<item component="ComponentInfo{fr.asterope/fr.asterope.MainActivity}" drawable="androidrun"/>

--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -13389,7 +13389,7 @@
 
 	<!-- LSPosed -->
 	<item component="ComponentInfo{org.lsposed.manager/org.lsposed.manager.ui.activity.MainActivity}" drawable="lsposed"/>
-	<item component="ComponentInfo{com.android.shell/com.android.shell.android.app.AppDetailsActivity}" drawable="lsposed"/>	
+	<item component="ComponentInfo{com.android.shell/android.app.AppDetailsActivity}" drawable="lsposed"/>	
 
 	<!-- LTE Cleaner -->
 	<item component="ComponentInfo{theredspy15.ltecleanerfoss/theredspy15.ltecleanerfoss.MainActivity}" drawable="ltecleaner"/>

--- a/other/inventory_og.svg
+++ b/other/inventory_og.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="inventory_og.svg">
+  <defs
+     id="defs2">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="1.4379461 : -0.4312546 : 0"
+       inkscape:vp_y="-15.296395 : 171.50999 : 0"
+       inkscape:vp_z="1.6079288 : 1.419626 : 0"
+       inkscape:persp3d-origin="-0.22357282 : 10.23025 : 1"
+       id="perspective902" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="30.752007"
+     inkscape:cy="21.729419"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg8"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1860"
+     inkscape:window-height="1052"
+     inkscape:window-x="60"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path933"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:0.26458335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 6.74105,7.1385587 A 2.1572674,1.5902784 54.957527 0 1 4.9439663,8.4917403 2.1572674,1.5902784 54.957527 0 1 3.1468826,6.0268962 2.1572674,1.5902784 54.957527 0 1 4.9439663,4.6737145 2.1572674,1.5902784 54.957527 0 1 6.74105,7.1385587 Z M 6.111074,6.9175957 A 1.3177195,1.0468381 52.181809 0 1 5.5329996,7.8167068 1.3177195,1.0468381 52.181809 0 1 4.3768507,7.5483619 1.3177195,1.0468381 52.181809 0 1 3.7987765,6.380906 M 5.5633949,6.0107972 A 0.20224384,0.14908862 54.957517 0 1 5.3949183,6.1376581 0.20224384,0.14908862 54.957517 0 1 5.2264417,5.9065789 0.20224384,0.14908862 54.957517 0 1 5.3949183,5.7797182 0.20224384,0.14908862 54.957517 0 1 5.5633949,6.0107972 Z M 4.3765738,5.7214195 A 0.20224384,0.14908862 54.957517 0 1 4.2080972,5.8482803 0.20224384,0.14908862 54.957517 0 1 4.0396206,5.6172012 0.20224384,0.14908862 54.957517 0 1 4.2080972,5.4903404 0.20224384,0.14908862 54.957517 0 1 4.3765738,5.7214195 Z m 0.070341,-3.5121187 0.06199,1.30103 M 9.0651539,4.2227996 8.9411745,10.449158 M 1.1924503,3.0456774 4.4469143,2.2093007 11.513751,2.9837235 M 1.1924503,3.0456773 1.7503584,8.2807747 8.9411745,10.449158 11.358776,8.3427287 11.513751,2.9837235 9.065154,4.2227997 Z"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
- Root Version of the App (Same Dev)
- Hanping Pro + Cantonese Version (Same Icon)
- Andoku 2 & 3 existing Sudoku Icon
- Super Image Paid Version
- existing Icon for Insomnia
- 2 more Kustom Apps joining the family
- existing Icon for Now in Android (close enough ?)
- Generic Android Icon for Captive Portal & Orange
- existing for IPWidget (purely personal taste)
- existing for Classic Power Menu + Digital Detox (Power Button...)
- existing for NekoSMS (LSPosed module to filter, you guessed it, SMS)

Obviously feel free to reject, change or suggest changes if some additions get to "personal"/repetitive.

(I'll get more descriptive with the commits at some point...promise!)