### PR TITLE
Added missing entries for discord's new app icons

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -6579,9 +6579,25 @@
 	<item component="ComponentInfo{com.discord/com.discord.MainActivity}" drawable="discord"/>
 	<item component="ComponentInfo{com.discord/com.discord.main.MainActivity}" drawable="discord"/>
 	<item component="ComponentInfo{com.discord/com.discord.main.MainDefault}" drawable="discord"/>
-	<item component="ComponentInfo{com.discord/com.discord.main.MainGalaxy}" drawable="discord"/>
 	<item component="ComponentInfo{com.discord/com.discord.main.MainBrandDark}" drawable="discord"/>
-	<item component="ComponentInfo{com.discord/com.discord.main.MainCherryBlossom}" drawable="discord" />
+	<item component="ComponentInfo{com.discord/com.discord.main.MainMatteDark}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainMatteLight}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainPastel}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainPirate}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainCamo}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainSunset}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainGalaxy}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainY2K}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainCherryBlossom}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainBeanie}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainGaming}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainCircuit}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainHoloWaves}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainBlush}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainAngry}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainManga}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainController}" drawable="discord"/>
+	<item component="ComponentInfo{com.discord/com.discord.main.MainMushroom}" drawable="discord"/>
 
 	<!-- Discover -->
 	<item component="ComponentInfo{com.discoverfinancial.mobile/com.discoverfinancial.mobile.MainActivity}" drawable="discover"/>
@@ -25363,7 +25379,25 @@
 	<!-- Vendetta -->
 	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainActivity}" drawable="discord_alt_2"/>
 	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainDefault}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainBrandDark}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainMatteDark}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainMatteLight}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainPastel}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainPirate}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainCamo}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainSunset}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainGalaxy}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainY2K}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainCherryBlossom}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainBeanie}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainGaming}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainCircuit}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainHoloWaves}" drawable="discord_alt_2"/>
 	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainBlush}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainAngry}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainManga}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainController}" drawable="discord_alt_2"/>
+	<item component="ComponentInfo{dev.beefers.vendetta/com.discord.main.MainMushroom}" drawable="discord_alt_2"/>
 
 	<!-- Vendetta Manager -->
 	<item component="ComponentInfo{dev.beefers.vendetta.manager/dev.beefers.vendetta.manager.ui.activity.MainActivity}" drawable="vendetta_manager"/>


### PR DESCRIPTION
Discord and Vendetta were missing entries for the other app icons available for a user to chose from.

Vanilla Discord had entries for the default app icon as well as for the `Galaxy` icon `BrandDark` icon and the `CherryBlossom` icon.

Vendetta had entries for the default app icon as well as for the `Blush` icon.

I have added more entries allowing for Arcticons to apply automatically whenever a user changes the icon within the Discord app.

\----
Hope I didnt break the guidelines, I dont make many pull requests as I'm not exactly sure how they work xD