### PR TITLE
Add some lookalike icons

### DIFF
--- a/other/appfilter.xml
+++ b/other/appfilter.xml
@@ -12870,6 +12870,9 @@
 	<!-- LanXchange -->
 	<item component="ComponentInfo{de.tobifleig.lxc/de.tobifleig.lxc.plaf.android.activity.MainActivity}" drawable="lanxchange"/>
 
+	<!-- Lapse -->
+	<item component="ComponentInfo{com.cornago.stefano.lapse/com.cornago.stefano.lapse.activities.StartActivity}" drawable="plagueinc"/>
+
 	<!-- Lark Player -->
 	<item component="ComponentInfo{com.dywx.larkplayer/com.dywx.larkplayer.main.MainActivity}" drawable="lark_player"/>
 
@@ -13639,6 +13642,9 @@
 
 	<!-- Lucia -->
 	<item component="ComponentInfo{digital.selfdefense.lucia/digital.selfdefense.lucia.MainActivity}" drawable="lucia"/>
+
+  	<!-- Lucid -->
+	<item component="ComponentInfo{fm.lucid.android/fm.lucid.android.ui.launcher.LauncherActivity}" drawable="remind"/>
 
 	<!-- luckin coffee -->
 	<item component="ComponentInfo{com.lucky.luckyclient/com.luckin.client.main.splash.SplashActivity}" drawable="luckin_coffee"/>
@@ -15035,6 +15041,9 @@
 
 	<!-- Molotov -->
 	<item component="ComponentInfo{tv.molotov.app/tv.molotov.android.splash.SplashActivity}" drawable="molotov"/>
+
+	<!-- Moments -->
+	<item component="ComponentInfo{com.rpedigoni.momentsappv1/com.rpedigoni.momentsappv1.MainActivity}" drawable="loop_infinity"/>
 
 	<!-- MoMo -->
 	<item component="ComponentInfo{com.mservice.momotransfer/vn.momo.platform.MainActivity}" drawable="momo"/>
@@ -20688,6 +20697,9 @@
 	<!-- Samsung Shop -->
 	<item component="ComponentInfo{com.samsung.ecomm.global.in/com.samsung.ecomm.MainActivity}" drawable="samsung_shop"/>
 	<item component="ComponentInfo{com.samsung.ecomm.global.in/com.samsung.ecomm.global.shop_app.MainActivity}" drawable="samsung_shop"/>
+
+	<!-- Samsung Smart Camera App -->
+	<item component="ComponentInfo{com.samsungimaging.connectionmanager/com.samsungimaging.connectionmanager.app.cm.Main}" drawable="image_sync"/>
 
 	<!-- Samsung Smart Switch -->
 	<item component="ComponentInfo{com.sec.android.easyMover/com.sec.android.easyMover.DistributionActivity}" drawable="samsung_smart_switch"/>


### PR DESCRIPTION
Inspired by _Niagara Launcher_'s [_Icon Assistant_](https://help.niagaralauncher.app/article/130-icon-assistant), I found some existing icons that could be a good fit for other apps.
As such, I added them to the `appfilter.xml`, without duplicating the SVGs.
I'm not sure if there are any rules about this; let me know if you'd like to handle this differently.

- [Lapse](https://play.google.com/store/apps/details?id=com.cornago.stefano.lapse)
- [Lucid](https://play.google.com/store/apps/details?id=fm.lucid.android)
- [Moments](https://play.google.com/store/apps/details?id=com.rpedigoni.momentsappv1)
- [Samsung Smart Camera App](https://play.google.com/store/apps/details?id=com.samsungimaging.connectionmanager)